### PR TITLE
Fix WiFi doc , add two diagnostic words

### DIFF
--- a/esp32/builtins.h
+++ b/esp32/builtins.h
@@ -405,6 +405,8 @@ static cell_t FromIP(IPAddress ip) {
   XV(WiFi, "WiFi.status", WIFI_STATUS, PUSH WiFi.status()) \
   XV(WiFi, "WiFi.macAddress", WIFI_MAC_ADDRESS, WiFi.macAddress(b0); DROP) \
   XV(WiFi, "WiFi.localIP", WIFI_LOCAL_IPS, PUSH FromIP(WiFi.localIP())) \
+  XV(WiFi, "WiFi.gatewayIP", WIFI_GATEWAY_IPS, PUSH FromIP(WiFi.gatewayIP())) \
+  XV(WiFi, "WiFi.subnetMask", WIFI_SUBNET_MASKS, PUSH FromIP(WiFi.subnetMask())) \
   XV(WiFi, "WiFi.mode", WIFI_MODE, WiFi.mode((wifi_mode_t) n0); DROP) \
   XV(WiFi, "WiFi.setTxPower", WIFI_SET_TX_POWER, WiFi.setTxPower((wifi_power_t) n0); DROP) \
   XV(WiFi, "WiFi.getTxPower", WIFI_GET_TX_POWER, PUSH WiFi.getTxPower()) \

--- a/site/ESP32forth.html
+++ b/site/ESP32forth.html
@@ -455,6 +455,8 @@ Wifi.disconnect ( -- )
 WiFi.status ( -- n )
 WiFi.macAddress ( a -- )
 WiFi.localIP ( -- ip )
+WiFi.gatewayIP ( -- ip )
+WiFi.subnetMask ( -- ip )
 WiFi.mode ( mode -- ) WIFI_MODE_NULL WIFI_MODE_STA WIFI_MODE_AP WIFI_MODE_APSTA
 WiFi.setTxPower ( powerx4 -- )   Set power x4
 WiFi.getTxPower ( -- powerx4 )   Get power x4


### PR DESCRIPTION
The order in the documentation of `WiFi.config` is mixed up. This fixes the order. You can verify this for yourself with the accompanying diagnostic words.

Reference:

```c
bool config(IPAddress local_ip,
            IPAddress gateway,
            IPAddress subnet,
            IPAddress dns1 = (uint32_t)0x00000000,
            IPAddress dns2 = (uint32_t)0x00000000);
```

https://github.com/espressif/arduino-esp32/blob/2.0.13/libraries/WiFi/src/WiFiSTA.h#L58