### PR TITLE
Fix the links after pico-ice doc changed.

### DIFF
--- a/site/pico-ice.html
+++ b/site/pico-ice.html
@@ -85,9 +85,9 @@ limitations under the License.
   <li>Copy ueforth-pico-ice.uf2 to the mounted drive.</li>
 </ul>
 <br/>
-<img src="https://pico-ice.tinyvision.ai/images/pico_ice_reset_button.jpg" width="300" height="auto">
+<img src="https://pico-ice.tinyvision.ai/pico_ice_reset_button.jpg" width="300" height="auto">
 <br/>
-<a href="https://pico-ice.tinyvision.ai/programming_the_mcu.html">See detailed instructions for MCU programming</a>
+<a href="https://pico-ice.tinyvision.ai/md_programming_the_mcu.html">See detailed instructions for MCU programming</a>
 </p>
 
 <h2>Use</h2>
@@ -164,7 +164,7 @@ adc_irq_set_enabled ( f -- ) Enable/disable ADC interrupts
 
 <h5>ice</h5>
 These words are inside the <code>ice</code> vocabulary.
-See <a href="https://pico-ice.tinyvision.ai/pico_ice_sdk.html">here</a>
+See <a href="https://pico-ice.tinyvision.ai/modules.html">here</a>
 for details on the underlying SDK.
 <pre>
 ice_cram_open ( -- ) Open FPGA config RAM connection.


### PR DESCRIPTION
Apologies, the documentation got changed to use Doxygen just a few days ago!
It adds all sorts of things to the file names, so here are the needed changes.

There was also a few fixes in a new release `v1.5` of the SDK (or latest `main` branch), which should help get the USB side of thigs more stable.

Impressive work there! This means the whole pico-ice library got mapped! Good thing that the pico-ice-sdk does not use too many complex data structures, I will try to keep it that way as much as possible knowing it helps this project.

Have a nice day,
Josuah.