### PR TITLE
fix high cpu load in web version #66

### DIFF
--- a/web/utils.fs
+++ b/web/utils.fs
@@ -16,9 +16,9 @@ web definitions
 
 : web-type ( a n -- ) web-type-raw if pause then ;
 ' web-type is type
-: web-key ( -- n ) begin pause web-key-raw dup 0< 0= if exit then drop again ;
+: web-key ( -- n ) begin pause? if pause else yield then web-key-raw dup 0< 0= if exit then drop again ;
 ' web-key is key
-: web-key? ( -- f ) pause web-key?-raw ;
+: web-key? ( -- f ) pause? if pause else yield then web-key?-raw ;
 ' web-key? is key?
 ' web-terminate is terminate
 
@@ -68,7 +68,7 @@ web definitions
   r> r> session? removeItem
 ;
 
-: yielding  begin 50 ms yield again ;
+: yielding  begin pause yield again ;
 ' yielding 10 10 task yielding-task
 yielding-task start-task
 


### PR DESCRIPTION
(sorry @flagxor I've used a LLM for fixing this, here is the report, it seemed to be a legit bug)

Three changes in web/utils.fs:                                                                         
                                                     
  1. web-key: begin pause web-key-raw... → begin pause? if pause else yield then web-key-raw...          
                                                                                                         
  Exact mirror of the POSIX fix in termios-key: when other tasks are running, cooperate via pause; when  
  alone, hand control back to the browser via yield.                                                     
                                                                                                         
  2. web-key?: same pause?/yield pattern.                   

  3. yielding: begin 50 ms yield again → begin pause yield again                                         
   
  This was the main source of the problem: 50 ms loops via pause for 50 real milliseconds at full CPU    
  before calling yield. With begin pause yield again, the sequence becomes: pause (yields to other tasks)
   → yield (hands control back to the browser) → the browser calls back via setTimeout(run, 0) ~4ms      
  later. The VM now only runs for a few microseconds per 4ms cycle → near-zero CPU usage.
